### PR TITLE
correct the link to also show the rename made in the wled repo

### DIFF
--- a/docs/advanced/custom-features.md
+++ b/docs/advanced/custom-features.md
@@ -6,7 +6,7 @@ hide:
 ---
 
 !!! warning
-    _Note: this page is now out of date, see updated functionality in the code ([WLED/usermods/EXAMPLE_v2](https://github.com/Aircoookie/WLED/tree/master/usermods/EXAMPLE_v2))_
+    _Note: this page is now out of date, see updated functionality in the code ([WLED/usermods/EXAMPLE](https://github.com/wled/WLED/tree/main/usermods/EXAMPLE))_
 
 This page is intended for those wishing to modify the WLED code to add their own functionality.
 


### PR DESCRIPTION
the example v2 are renamed to Example now. this link didnt work anymore
fitting commit in the WLED Repo
https://github.com/wled/WLED/commit/070b08a9e6c7323c37ddcfbb224b531898b864e7 