### PR TITLE
Update dmx-output.md

### DIFF
--- a/docs/interfaces/dmx-output.md
+++ b/docs/interfaces/dmx-output.md
@@ -21,7 +21,9 @@ hide:
 
 #### software setup
 
-For the DMX feature to work, you'll need to compile WLED from source. It's not a big deal, you can do it! [Here](/basics/getting-started) is the Quick Start guide. There you'll find the section "i want to modify WLED".
+For the DMX feature to work, you need to flash a WLED binary with DMX enabled. Among the latest releases, search for the .bin suuting your board with the postfix "_dmx".
+
+Alternatively, you'll need to compile WLED from source. It's not a big deal, you can do it! [Here](/basics/getting-started) is the Quick Start guide. There you'll find the section "i want to modify WLED".
 
 1. make sure, you can compile the latest version of WLED without any issues. Then continue.
 
@@ -37,13 +39,13 @@ For the DMX feature to work, you'll need to compile WLED from source. It's not a
 
 #### hardware setup
 
-The DMX output required the use of a MAX485 transceiver connected to the TX-pin of the ESP in order to produce DMX output.
+The DMX output required the use of a MAX485 / SN 75176 transceiver connected to GPIO2 of your ESP. As of now, the pin is hardcoded inside of WLED (see below).
 
 I am currently working on an open source PCB design to go along with this feature.
 
 For information about the use of DMX with ESP8266, you might like to read [this](https://robertoostenveld.nl/art-net-to-dmx512-with-esp8266/) tutorial by [Robert Oostenveld](https://robertoostenveld.nl/). Note this is just background information about the hardware and you do not need any of the code listed here when using WLED output.
 
-If you need to use another pin for output than the TX-pin, you'll need to change this in the ESP-Dmx library itself. This setting is located in src/dependencies/dmx/ESPDMX.cpp on line 31.
+If you need to use another pin for output than the GPIO2, you'll need to change this in the ESP-Dmx library itself. This setting is located in src/dependencies/dmx/ESPDMX.cpp on line 31.
 
 #### questions
 

--- a/docs/interfaces/dmx-output.md
+++ b/docs/interfaces/dmx-output.md
@@ -21,7 +21,7 @@ hide:
 
 #### software setup
 
-For the DMX feature to work, you need to flash a WLED binary with DMX enabled. Among the latest releases, search for the .bin suuting your board with the postfix "_dmx".
+For the DMX feature to work, you need to flash a WLED binary with DMX enabled. Among the latest releases, search for the corresponding .bin for your board with the postfix "_dmx".
 
 Alternatively, you'll need to compile WLED from source. It's not a big deal, you can do it! [Here](/basics/getting-started) is the Quick Start guide. There you'll find the section "i want to modify WLED".
 


### PR DESCRIPTION
Outdated information that kept me Debugging for hours. DMX-ready Versions are Provider with every new release. The correct hardcoded pin is GPIO2, not TX.