### PR TITLE
Add Go implementation to DDP library list

### DIFF
--- a/docs/interfaces/ddp.md
+++ b/docs/interfaces/ddp.md
@@ -24,3 +24,4 @@ If you are implementing the protocol to send packets to WLED, do not bother impl
  - [LedFX/devices/ddp.py](https://github.com/LedFx/LedFx/blob/main/ledfx/devices/ddp.py) LedFX's implementation for sending DDP packets to WLED.
  - [yeonic/plugins/wled](https://github.com/YeonV/yeonic/blob/main/src/plugins/wled.ts#L51) TypeScript (javascript) implementation - Needs a nodejs like environment on Chromium engine.
  - [TypeScript](https://gist.github.com/piretek/16b2c729135a4a64d60d48a15fb36996) Simple typescript implementation using `dgram` with `wled-client` in clean NodeJS environment.
+ - [Distributed Display Protocol (DDP) in Go](https://github.com/coral/ddp) Small Go library to send DDP packets to WLED.


### PR DESCRIPTION
Saw that my Rust implementation was on the list and realized I also did a Go one for another project that's used in production. Adding it to the list.