### PR TITLE
Firefox works with the web installer now

### DIFF
--- a/docs/basics/install-binary.md
+++ b/docs/basics/install-binary.md
@@ -10,7 +10,7 @@ hide:
 !!! tip
     This is by far the easiest and fastest way to get WLED up and running!
 
-Make sure you are running a recent desktop Chrome or Edge browser and head over to the [WLED installer site](https://install.wled.me)!
+Make sure you are running a desktop version of Chrome, Edge, Opera, or Firefox 151 or newer, and head over to the [WLED installer site](https://install.wled.me)! Safari cannot be used, as it does not support the browser feature the installer needs to talk to your board.
 This installer is not yet available for ESPs with flash chips smaller than 4MB (e.g. ESP01)
 
 !!! tip


### PR DESCRIPTION
The page says Chrome or Edge only. Firefox shipped Web Serial in 151, which is the API the installer uses to talk to the board, so it works there too. Safari has no support at all, which the page never said, so Safari users had no way to know why it wouldn't work for them.

Support per [MDN compat data](https://github.com/mdn/browser-compat-data/blob/main/api/Serial.json):

| Browser | Web Serial |
|---|---|
| Chrome | 89+ |
| Edge | mirrors Chrome |
| Opera | mirrors Chrome |
| Firefox | 151+ |
| Safari | none |

The version is named rather than saying "recent Firefox", since 151 is new enough that many Firefox users won't have it yet.
