### PR TITLE
Restructure the Community Usermods page and add support and enabling pointers

### DIFF
--- a/docs/advanced/community-usermods.md
+++ b/docs/advanced/community-usermods.md
@@ -2,7 +2,7 @@
 title: Community Usermods
 ---
 
-This page is an index of usermods written by the WLED community. Entries are maintained by their authors; the WLED project does not test or endorse them.
+This page is an index of usermods that live outside the WLED repository, written and maintained by community members. WLED itself also ships with over 70 built-in usermods (audio-reactive, sensors, displays, and more) in its [`usermods/` directory](https://github.com/wled/WLED/tree/main/usermods), each with its own README; those are not listed here. Entries below are maintained by their authors; the WLED project does not test or endorse them.
 
 To help people find your usermod even before it appears here, tag your GitHub repository with the [`wled-usermod`](https://github.com/topics/wled-usermod) topic.
 
@@ -23,31 +23,58 @@ To help people find your usermod even before it appears here, tag your GitHub re
     The WLED project cannot verify the safety or quality of community usermods.
     **You are solely responsible for any third-party code you choose to run on your devices.**
 
-## Index
+Questions and bug reports for a listed usermod go to its author, the usual way is an issue on the usermod's own repository (the name links there). The WLED issue tracker and Discord can't help with third-party code.
 
-| Name | Description | Author | Platforms | License | Notes |
-|---|---|---|---|---|---|
-| [wled-usermod-example](https://github.com/wled/wled-usermod-example) | Annotated template — use as template to start your own usermod | @wled | both | EUPL | Official starting point |
-| [user_fx](https://github.com/wled/WLED/tree/main/usermods/user_fx) | Community effects usermod — add your own effects here or use as a template | @wled | both | EUPL | Ships with WLED; enable with `custom_usermods = user_fx` |
-| [Word Clock FX](https://github.com/AustinSaintAubin/wled-usermod-word-clock-fx-16x16) | 16×16 English word-clock as a first-class WLED effect, with Open-Meteo weather words/presets and corner-button LEDs | @AustinSaintAubin | esp32 | MIT |  |
-| [Segment Power Sync](https://github.com/sharn25/wled-segment-power-sync) | Automatically synchronizes individual segment power states with the overall master power state. Ideal when using a relay to cut mains power to LEDs. | @sharn25 | both | MIT |  |
-| [PowerManager](https://github.com/intermittech/wled-usermod-powermanager) | Per-segment power switching: relay/MOSFET outputs follow segment on/off, with anti-flash power sequencing, PSU stabilization and a Master AC relay | @intermittech | esp32 | EUPL | Grown from the built-in multi_relay usermod |
-| [SHTC3_v2](https://github.com/lost-hope/SHTC3_v2) | Adds readout for the SHTC3 temperature and humidity sensor. Also publishes the values over MQTT and sends out HA sensor messages | `@lost-hope` | both | EUPL |  |
+To compile any of these into your own firmware, follow [Enabling usermods](/advanced/custom-features#enabling-usermods) on the Custom Features page.
 
+## Official Starting Points
 
-## Adding your usermod to the list
+Two usermods come from the WLED project itself and are the best places to start writing your own:
 
-Open a pull request to [WLED-Docs](https://github.com/wled/WLED-Docs) adding a row to the table above. 
+- [wled-usermod-example](https://github.com/wled/wled-usermod-example): annotated template, use it as the starting point for your own usermod.
+- [user_fx](https://github.com/wled/WLED/tree/main/usermods/user_fx): community effects usermod that ships with WLED, add your own effects to it or use it as a template. Enable it with `custom_usermods = user_fx`.
 
-Use this format:
+## Community Index
+
+### [PowerManager](https://github.com/intermittech/wled-usermod-powermanager)
+
+Per-segment power switching: relay/MOSFET outputs follow segment on/off, with anti-flash power sequencing, PSU stabilization and a Master AC relay. Grown from the built-in multi_relay usermod.
+
+_By [@intermittech](https://github.com/intermittech). Platforms: esp32. License: EUPL._
+
+### [Segment Power Sync](https://github.com/sharn25/wled-segment-power-sync)
+
+Automatically synchronizes individual segment power states with the overall master power state. Ideal when using a relay to cut mains power to LEDs.
+
+_By [@sharn25](https://github.com/sharn25). Platforms: both. License: MIT._
+
+### [SHTC3_v2](https://github.com/lost-hope/SHTC3_v2)
+
+Adds readout for the SHTC3 temperature and humidity sensor. Also publishes the values over MQTT and sends out HA sensor messages.
+
+_By [@lost-hope](https://github.com/lost-hope). Platforms: both. License: EUPL._
+
+### [Word Clock FX](https://github.com/AustinSaintAubin/wled-usermod-word-clock-fx-16x16)
+
+16×16 English word-clock as a first-class WLED effect, with Open-Meteo weather words/presets and corner-button LEDs.
+
+_By [@AustinSaintAubin](https://github.com/AustinSaintAubin). Platforms: esp32. License: MIT._
+
+## Add Your Usermod
+
+Open a pull request to [WLED-Docs](https://github.com/wled/WLED-Docs) adding a section to the index above, in this format:
 
 ```markdown
-| [Name](https://github.com/you/your-usermod) | Short description | @yourname | esp32 | GPLv3 |  |
+### [Name](https://github.com/you/your-usermod)
+
+One or two sentences on what it does.
+
+_By [@yourname](https://github.com/yourname). Platforms: esp32. License: GPLv3._
 ```
 
-Platforms: `esp32`, `esp8266`, or `both`.
+Platforms: `esp32`, `esp8266`, or `both`. Keep the index alphabetical.
 
-### Choosing a license for your usermod
+## Choosing a License
 
 A usermod is compiled into the WLED firmware, so it becomes part of a modified WLED build. WLED uses the **EUPL-1.2** licence. If you share a firmware binary that includes your usermod, also share the source code for that build and use EUPL-1.2 or a compatible open-source licence for the combined firmware.
 

--- a/docs/advanced/community-usermods.md
+++ b/docs/advanced/community-usermods.md
@@ -2,7 +2,7 @@
 title: Community Usermods
 ---
 
-This page is an index of usermods that live outside the WLED repository, written and maintained by community members. WLED itself also ships with over 70 built-in usermods (audio-reactive, sensors, displays, and more) in its [`usermods/` directory](https://github.com/wled/WLED/tree/main/usermods), each with its own README; those are not listed here. Entries below are maintained by their authors; the WLED project does not test or endorse them.
+This page is an index of usermods that live outside the WLED repository, written and maintained by community members. The WLED repository also carries many usermods of its own (audio-reactive, sensors, displays, and more) in its [`usermods/` directory](https://github.com/wled/WLED/tree/main/usermods), each with its own README. Those are not listed here, and like the ones below they need a custom build to use. Entries below are maintained by their authors; the WLED project does not test or endorse them.
 
 To help people find your usermod even before it appears here, tag your GitHub repository with the [`wled-usermod`](https://github.com/topics/wled-usermod) topic.
 

--- a/docs/advanced/community-usermods.md
+++ b/docs/advanced/community-usermods.md
@@ -23,7 +23,7 @@ To help people find your usermod even before it appears here, tag your GitHub re
     The WLED project cannot verify the safety or quality of community usermods.
     **You are solely responsible for any third-party code you choose to run on your devices.**
 
-Questions and bug reports for a listed usermod go to its author, the usual way is an issue on the usermod's own repository (the name links there). The WLED issue tracker and Discord can't help with third-party code.
+Questions and bug reports for a listed usermod go to its author. The usual way is an issue on the usermod's repository, linked from its name. The WLED issue tracker and Discord can't help with third-party code.
 
 To compile any of these into your own firmware, follow [Enabling usermods](/advanced/custom-features#enabling-usermods) on the Custom Features page.
 
@@ -32,7 +32,7 @@ To compile any of these into your own firmware, follow [Enabling usermods](/adva
 Two usermods come from the WLED project itself and are the best places to start writing your own:
 
 - [wled-usermod-example](https://github.com/wled/wled-usermod-example): annotated template, use it as the starting point for your own usermod.
-- [user_fx](https://github.com/wled/WLED/tree/main/usermods/user_fx): community effects usermod that ships with WLED, add your own effects to it or use it as a template. Enable it with `custom_usermods = user_fx`.
+- [user_fx](https://github.com/wled/WLED/tree/main/usermods/user_fx): official effects usermod that ships with WLED, add your own effects to it or use it as a template. Enable it with `custom_usermods = user_fx`.
 
 ## Community Index
 
@@ -40,7 +40,7 @@ Two usermods come from the WLED project itself and are the best places to start 
 
 Per-segment power switching: relay/MOSFET outputs follow segment on/off, with anti-flash power sequencing, PSU stabilization and a Master AC relay. Grown from the built-in multi_relay usermod.
 
-_By [@intermittech](https://github.com/intermittech). Platforms: esp32. License: EUPL._
+_By [@intermittech](https://github.com/intermittech). Platforms: esp32. License: EUPL-1.2._
 
 ### [Segment Power Sync](https://github.com/sharn25/wled-segment-power-sync)
 
@@ -52,7 +52,7 @@ _By [@sharn25](https://github.com/sharn25). Platforms: both. License: MIT._
 
 Adds readout for the SHTC3 temperature and humidity sensor. Also publishes the values over MQTT and sends out HA sensor messages.
 
-_By [@lost-hope](https://github.com/lost-hope). Platforms: both. License: EUPL._
+_By [@lost-hope](https://github.com/lost-hope). Platforms: both. License: EUPL-1.2._
 
 ### [Word Clock FX](https://github.com/AustinSaintAubin/wled-usermod-word-clock-fx-16x16)
 

--- a/docs/advanced/custom-features.md
+++ b/docs/advanced/custom-features.md
@@ -12,7 +12,7 @@ This page covers how to add custom functionality to WLED, either through usermod
 
 ## Usermods
 
-Usermods are self-contained modules you can add to a WLED build without touching core source files. WLED ships with many usermods in the `usermods/` directory (audio-reactive, temperature sensors, displays, rotary encoders, and more).
+Usermods are self-contained modules you can add to a WLED build without touching core source files. WLED ships with many usermods in the [`usermods/` directory](https://github.com/wled/WLED/tree/main/usermods) (audio-reactive, temperature sensors, displays, rotary encoders, and more), each documented by its own README. Usermods maintained outside the WLED repository are indexed on the [Community Usermods](/advanced/community-usermods) page.
 
 ### Enabling usermods
 


### PR DESCRIPTION
Fixes #327.

The warning banner the issue asked for already landed in 6ad57435; this completes the remaining asks and restructures the page:

- Says where to get support for a listed usermod (its author, via the usermod's repository)
- Links the [Enabling usermods](https://kno.wled.ge/advanced/custom-features/#enabling-usermods) walkthrough on the Custom Features page
- Replaces the index table with one section per usermod: the descriptions were making rows wrap badly, and sections give each usermod a linkable anchor and a table of contents entry. Official starting points (wled-usermod-example, user_fx) are split from the community index, community entries are alphabetized, author handles link to their GitHub profiles, and the contribution instructions show the new block format
- Clarifies scope: the page indexes out-of-tree usermods, with a pointer to the 70+ built-in ones in the firmware's [`usermods/` directory](https://github.com/wled/WLED/tree/main/usermods) (and a matching link plus cross-reference on the Custom Features page)

All six listed repos verified live (none archived, all pushed within the last two months), and the enabling mechanism link describes the current WLED 16 `custom_usermods` flow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the distinction between built-in and community usermods.
  * Added guidance for reporting issues, compiling usermods, and contributing.
  * Reorganized the usermod directory into official starting points, community entries, and contribution instructions.
  * Expanded descriptions and metadata for existing usermods.
  * Updated custom features documentation with links to usermod resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->