### PR TITLE
Rework the internet access page: easiest options first, all routes as tabs

### DIFF
--- a/docs/advanced/access-over-internet.md
+++ b/docs/advanced/access-over-internet.md
@@ -5,76 +5,64 @@ hide:
   # - toc
 ---
 
-WLED has no authentication and no HTTPS. Anyone who can reach it can change your configuration or flash new firmware. That means you can't expose it to the internet directly, but you can reach it safely through a VPN, a tunnel, or an authenticated reverse proxy. This page covers all three, easiest first.
+Control your LEDs from anywhere. Pick a route below: Tailscale is the easiest and gets most people there in about ten minutes, Cloudflare Tunnel gives you a login-protected public URL, HomeKit puts WLED in the Apple Home app, and Caddy, nginx, or Traefik work if you already run a reverse proxy at home.
+
+Already controlling WLED through [Home Assistant](https://www.home-assistant.io/integrations/wled/)? If you can reach Home Assistant remotely, you have secure remote control and don't need anything on this page.
 
 !!! warning "Never port forward WLED"
-    Under no circumstances port forward a WLED instance to the public internet.
-    WLED does not support HTTPS or authentication, so anyone who finds it has full control of the device.
+    WLED has no login on its control interface and no HTTPS. Port forwarding it to the internet gives anyone full control of the device, including flashing new firmware. Every option below adds that missing security layer in front.
 
-!!! tip "Already running Home Assistant?"
-    If you control WLED through [Home Assistant](https://www.home-assistant.io/integrations/wled/) and Home Assistant is reachable remotely, you already have secure remote control and don't need anything on this page.
+=== "Tailscale"
 
-## Recommended: Tailscale
+    [Tailscale](https://tailscale.com/) builds a private WireGuard network between your devices, so nothing is exposed to the public internet and you don't need to open ports or manage a domain and certificates. The free plan is enough for this.
 
-[Tailscale](https://tailscale.com/) is the easiest way to reach WLED from anywhere. It builds a private WireGuard network between your devices, so nothing is exposed to the public internet and you don't need to open ports or manage a domain and certificates. The free plan is enough for this.
+    WLED itself can't run Tailscale, so you need one always-on device at home (a Raspberry Pi, NAS, or home server) to act as a [subnet router](https://tailscale.com/kb/1019/subnets) that forwards traffic to your LAN. A Home Assistant box works too: its Tailscale add-on can advertise your LAN, and Tailscale has a [video walkthrough](https://www.youtube.com/watch?v=fMR8uvNIilI) of that setup.
 
-WLED itself can't run Tailscale, so you need one always-on device at home (a Raspberry Pi, NAS, or home server) to act as a [subnet router](https://tailscale.com/kb/1019/subnets) that forwards traffic to your LAN.
+    1. Create a Tailscale account and install the app on your phone or laptop.
+    2. Install Tailscale on the always-on device at home.
+    3. On that device, advertise your LAN subnet (adjust to match your network):
 
-1. Create a Tailscale account and install the app on your phone or laptop.
-2. Install Tailscale on the always-on device at home.
-3. On that device, advertise your LAN subnet (adjust to match your network):
+        ```sh
+        sudo tailscale set --advertise-routes=192.168.1.0/24
+        ```
 
-    ```
-    sudo tailscale up --advertise-routes=192.168.1.0/24
-    ```
+        On Linux you also need to enable IP forwarding, see the [subnet router guide](https://tailscale.com/kb/1019/subnets).
 
-    On Linux you also need to enable IP forwarding, see the [subnet router guide](https://tailscale.com/kb/1019/subnets).
+    4. In the [Tailscale admin console](https://login.tailscale.com/admin/machines), approve the advertised route on that machine.
 
-4. In the [Tailscale admin console](https://login.tailscale.com/admin/machines), approve the advertised route on that machine.
+    With Tailscale connected on your phone, open WLED's LAN IP in the browser or add it in the WLED app. Use the IP address, not `wled.local`, because mDNS names don't resolve across the tunnel. WLED also never gets a `.ts.net` name of its own, since it isn't running Tailscale.
 
-That's it. With Tailscale connected on your phone, open WLED's normal LAN IP in the browser or add it in the WLED app, exactly as if you were home.
+    If you'd rather not rely on a third party, a plain [WireGuard](https://www.wireguard.com/) tunnel to your router or a self-hosted [Headscale](https://headscale.net/) control server gets you the same result with more setup.
 
-If you'd rather not rely on a third party, a plain [WireGuard](https://www.wireguard.com/) tunnel to your router or a self-hosted [Headscale](https://headscale.net/) control server gets you the same result with more setup.
+=== "Cloudflare Tunnel"
 
-## Cloudflare Tunnel
+    [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) is a good option if you want to reach WLED from a device where you can't run a VPN client, or share access with someone else. A small daemon (`cloudflared`) on a machine in your LAN makes an outbound connection to Cloudflare, so no ports are opened on your router. You need a domain on Cloudflare (the free plan works).
 
-[Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) is a good option if you want to reach WLED from a device where you can't run a VPN client, or share access with someone else. A small daemon (`cloudflared`) on a machine in your LAN makes an outbound connection to Cloudflare, so no ports are opened on your router. You need a domain on Cloudflare (the free plan works).
+    !!! warning "The tunnel alone is not enough"
+        A tunnel without access control is just port forwarding with extra steps. You **must** put [Cloudflare Access](https://developers.cloudflare.com/cloudflare-one/policies/access/) in front of the tunnel so only you can log in.
 
-!!! warning "The tunnel alone is not enough"
-    A tunnel without access control is just port forwarding with extra steps. You **must** put [Cloudflare Access](https://developers.cloudflare.com/cloudflare-one/policies/access/) in front of the tunnel so only you can log in.
+    1. In the Cloudflare dashboard, go to **Networking > Tunnels** and create a tunnel. Install `cloudflared` on an always-on machine in your LAN using the command the dashboard gives you.
+    2. Add a public hostname for the tunnel, for example `wled.mydomain.example`, pointing to `http://<WLED-IP>`.
+    3. Under **Zero Trust**, create an Access application for that hostname with a policy that only allows your own login, for example email one-time PIN.
 
-1. In the Cloudflare dashboard, go to Zero Trust and create a tunnel. Install `cloudflared` on an always-on machine in your LAN using the command the dashboard gives you.
-2. Add a public hostname for the tunnel, for example `wled.mydomain.example`, pointing to `http://<WLED-IP>`.
-3. In Zero Trust, create an Access application for that hostname with a policy that only allows your own login, for example email one-time PIN.
+    Now `https://wled.mydomain.example` asks for your login first and only then shows WLED.
 
-Now `https://wled.mydomain.example` asks for your login first and only then shows WLED.
+=== "HomeKit"
 
-## Advanced: reverse proxy
+    If you're in the Apple ecosystem, you can put WLED in the Home app and let Apple handle the remote connection. You need a home hub (an Apple TV or HomePod) at home; the hub relays remote control through Apple's servers, so there's nothing to expose or configure, and Siri works too.
 
-If you already run a public-facing reverse proxy, you can publish WLED through it. Two requirements are non-negotiable:
+    The Home app's light controls cover power, brightness, and color. For the full WLED interface, use one of the other tabs.
 
-- The proxy **must implement access control**, so only trusted users reach WLED.
-- The proxy **must terminate TLS** and only accept HTTPS. Access control over plain HTTP leaks your credentials.
+    WLED doesn't speak HomeKit natively, so a bridge on your network translates:
 
-The proxy can't run on the WLED device itself. You need a server in your LAN:
-
-```
-[Public Internet]
-   |
-[Router]
-   |
-[Reverse Proxy]
-   |
-[WLED]
-```
-
-The general recipe is the same for every proxy: register a domain name (a dynamic DNS name works), get a Let's Encrypt certificate with automatic renewal, port forward TCP 443 from your router to the proxy, and configure an authenticated virtual host that proxies to WLED's LAN IP. WLED's live view uses a WebSocket, so the proxy must pass WebSocket upgrades through.
+    - If you run Home Assistant, enable the [HomeKit Bridge](https://www.home-assistant.io/integrations/homekit/) integration, expose the WLED light entity, and scan the pairing QR code with the Home app.
+    - Without Home Assistant, run [Homebridge](https://homebridge.io/) on a Raspberry Pi or home server with a WLED plugin such as [homebridge-simple-wled](https://www.npmjs.com/package/homebridge-simple-wled), which can also expose chosen effects and presets as HomeKit switches.
 
 === "Caddy"
 
-    Caddy obtains and renews the Let's Encrypt certificate automatically, serves HTTPS only by default, and proxies WebSockets without extra configuration.
+    For an existing [Caddy](https://caddyserver.com/) server in your LAN with a domain pointed at your home IP (dynamic DNS works). The proxy must require a login and serve HTTPS only; Caddy does the HTTPS part by default and obtains and renews the Let's Encrypt certificate automatically.
 
-    Generate a password hash with `caddy hash-password`, then in your `Caddyfile`:
+    Generate a password hash with `caddy hash-password`, put it in place of `PASSWORDHASH` in your `Caddyfile` (on Caddy older than 2.8, the directive is spelled `basicauth`):
 
     ```
     wled.mydomain.example {
@@ -85,11 +73,13 @@ The general recipe is the same for every proxy: register a domain name (a dynami
     }
     ```
 
-    Replace `192.168.1.50` with the IP or local hostname of your WLED device. Caddy needs ports 80 and 443 forwarded for certificate issuing.
+    Replace `192.168.1.50` with the IP or local hostname of your WLED device. Port forward TCP 80 and 443 from your router to the Caddy host so certificate issuing works.
 
 === "nginx"
 
-    nginx doesn't manage certificates itself, use [Certbot](https://certbot.eff.org/) to obtain and renew the Let's Encrypt certificate. Create the password file with `htpasswd -c /etc/nginx/.htpasswd yourusername`.
+    For an existing [nginx](https://nginx.org/) server in your LAN with a domain pointed at your home IP (dynamic DNS works) and TCP 443 forwarded to it. The proxy must require a login and serve HTTPS only. nginx doesn't manage certificates itself, use [Certbot](https://certbot.eff.org/) to obtain and renew the Let's Encrypt certificate before adding this server block, since nginx won't start while the certificate paths point at nothing. Certbot's default challenge also needs TCP 80 forwarded.
+
+    Create the password file with `htpasswd -c /etc/nginx/.htpasswd yourusername`, then:
 
     ```nginx
     server {
@@ -116,7 +106,9 @@ The general recipe is the same for every proxy: register a domain name (a dynami
 
 === "Traefik"
 
-    With a `letsencrypt` [certificate resolver](https://doc.traefik.io/traefik/https/acme/) configured in your static configuration, add this dynamic configuration. Generate the password hash with `htpasswd -nb yourusername mypassword`.
+    For an existing [Traefik](https://doc.traefik.io/traefik/) instance in your LAN with a domain pointed at your home IP (dynamic DNS works), TCP 443 forwarded to it, and a `letsencrypt` [certificate resolver](https://doc.traefik.io/traefik/https/acme/) configured. The proxy must require a login and serve HTTPS only.
+
+    Generate the password hash with `htpasswd -nb yourusername mypassword`, then add this dynamic configuration in a file your [file provider](https://doc.traefik.io/traefik/providers/file/) watches:
 
     ```yaml
     http:
@@ -144,4 +136,5 @@ The general recipe is the same for every proxy: register a domain name (a dynami
               - url: "http://192.168.1.50"
     ```
 
-Whichever option you choose, also enable the [OTA lock password](/advanced/ota-lock) so the firmware can't be replaced even by someone who gets past the first layer.
+!!! tip "Enable the OTA lock"
+    Whichever route you choose, also enable the [OTA lock password](/advanced/ota-lock) so the firmware can't be replaced even by someone who gets past the first layer.

--- a/docs/advanced/access-over-internet.md
+++ b/docs/advanced/access-over-internet.md
@@ -19,18 +19,18 @@ Already controlling WLED through [Home Assistant](https://www.home-assistant.io/
     WLED itself can't run Tailscale, so you need one always-on device at home (a Raspberry Pi, NAS, or home server) to act as a [subnet router](https://tailscale.com/kb/1019/subnets) that forwards traffic to your LAN. A Home Assistant box works too: its Tailscale add-on can advertise your LAN, and Tailscale has a [video walkthrough](https://www.youtube.com/watch?v=fMR8uvNIilI) of that setup.
 
     1. Create a Tailscale account and install the app on your phone or laptop.
-    2. Install Tailscale on the always-on device at home.
-    3. On that device, advertise your LAN subnet (adjust to match your network):
+    2. Install Tailscale on the always-on device at home and sign it in with `sudo tailscale up`.
+    3. On that device, advertise the route to your WLED devices. A single address is enough for one controller, and safer than opening the whole LAN:
 
         ```sh
-        sudo tailscale set --advertise-routes=192.168.1.0/24
+        sudo tailscale set --advertise-routes=192.168.1.50/32
         ```
 
-        On Linux you also need to enable IP forwarding, see the [subnet router guide](https://tailscale.com/kb/1019/subnets).
+        Use your own WLED IP, or a subnet like `192.168.1.0/24` if you have several devices to reach. On Linux you also need to enable IP forwarding, see the [subnet router guide](https://tailscale.com/kb/1019/subnets).
 
     4. In the [Tailscale admin console](https://login.tailscale.com/admin/machines), approve the advertised route on that machine.
 
-    With Tailscale connected on your phone, open WLED's LAN IP in the browser or add it in the WLED app. Use the IP address, not `wled.local`, because mDNS names don't resolve across the tunnel. WLED also never gets a `.ts.net` name of its own, since it isn't running Tailscale.
+    With Tailscale connected on your phone, open WLED's LAN IP in the browser or add it in the WLED app. Use the IP address, not `wled.local`, because mDNS names don't resolve across the tunnel. WLED also never gets a `.ts.net` name of its own, since it isn't running Tailscale. On a Linux client, run `sudo tailscale set --accept-routes` first; phones, Macs and Windows pick up the route on their own.
 
     If you'd rather not rely on a third party, a plain [WireGuard](https://www.wireguard.com/) tunnel to your router or a self-hosted [Headscale](https://headscale.net/) control server gets you the same result with more setup.
 
@@ -42,8 +42,8 @@ Already controlling WLED through [Home Assistant](https://www.home-assistant.io/
         A tunnel without access control is just port forwarding with extra steps. You **must** put [Cloudflare Access](https://developers.cloudflare.com/cloudflare-one/policies/access/) in front of the tunnel so only you can log in.
 
     1. In the Cloudflare dashboard, go to **Networking > Tunnels** and create a tunnel. Install `cloudflared` on an always-on machine in your LAN using the command the dashboard gives you.
-    2. Add a public hostname for the tunnel, for example `wled.mydomain.example`, pointing to `http://<WLED-IP>`.
-    3. Under **Zero Trust**, create an Access application for that hostname with a policy that only allows your own login, for example email one-time PIN.
+    2. Under **Zero Trust**, create an Access application for the hostname you plan to use, for example `wled.mydomain.example`, with a policy that only allows your own login, such as email one-time PIN. Do this before the next step, or WLED is briefly reachable by anyone.
+    3. Back in the tunnel, add that hostname as a public hostname pointing to `http://<WLED-IP>`.
 
     Now `https://wled.mydomain.example` asks for your login first and only then shows WLED.
 
@@ -137,4 +137,4 @@ Already controlling WLED through [Home Assistant](https://www.home-assistant.io/
     ```
 
 !!! tip "Enable the OTA lock"
-    Whichever route you choose, also enable the [OTA lock password](/advanced/ota-lock) so the firmware can't be replaced even by someone who gets past the first layer.
+    Whichever route you choose, also enable [OTA Lock](/advanced/ota-lock) and change its default passphrase `wledota`, so nobody who gets past the first layer can push new firmware over Wi-Fi.

--- a/docs/advanced/access-over-internet.md
+++ b/docs/advanced/access-over-internet.md
@@ -5,31 +5,58 @@ hide:
   # - toc
 ---
 
-WLED exposed to Internet safely with the help of a reverse proxy setup.
-This document describes the steps needed.
+WLED has no authentication and no HTTPS. Anyone who can reach it can change your configuration or flash new firmware. That means you can't expose it to the internet directly, but you can reach it safely through a VPN, a tunnel, or an authenticated reverse proxy. This page covers all three, easiest first.
 
-!!! warning "Port Forwarding"
-    Under no circumstances port forward WLED instance to the public internet.
-    WLED does not support HTTPS or authentication, leading to a fundamentally insecure setup.
+!!! warning "Never port forward WLED"
+    Under no circumstances port forward a WLED instance to the public internet.
+    WLED does not support HTTPS or authentication, so anyone who finds it has full control of the device.
 
-!!! tip "Consider VPN Tunneling"
-    If you only need access from a single device, such as your phone,
-    consider a point-to-point VPN tunnel instead. Configuring a tunnel
-    may require less configuration and maintenance than a HTTPS reverse proxy.
+!!! tip "Already running Home Assistant?"
+    If you control WLED through [Home Assistant](https://www.home-assistant.io/integrations/wled/) and Home Assistant is reachable remotely, you already have secure remote control and don't need anything on this page.
 
-# Reverse proxy requirements
+## Recommended: Tailscale
 
-WLED does not implement access control, allowing anyone able to connect to it change configuration or even update firmware.
-For a safe access, **the reverse proxy MUST implement access control** to only allow trusted users to access WLED.
+[Tailscale](https://tailscale.com/) is the easiest way to reach WLED from anywhere. It builds a private WireGuard network between your devices, so nothing is exposed to the public internet and you don't need to open ports or manage a domain and certificates. The free plan is enough for this.
 
-Secure access control cannot be implemented over insecure connection. **The reverse proxy MUST implement TLS termination**, only allowing access over HTTPS.
+WLED itself can't run Tailscale, so you need one always-on device at home (a Raspberry Pi, NAS, or home server) to act as a [subnet router](https://tailscale.com/kb/1019/subnets) that forwards traffic to your LAN.
 
-Reverse proxy cannot run on the WLED device.
-You need a server in your local network to perform the encryption and proxying.
+1. Create a Tailscale account and install the app on your phone or laptop.
+2. Install Tailscale on the always-on device at home.
+3. On that device, advertise your LAN subnet (adjust to match your network):
 
-# Example
+    ```
+    sudo tailscale up --advertise-routes=192.168.1.0/24
+    ```
 
-Assuming the following network setup, using Caddy as a reverse proxy:
+    On Linux you also need to enable IP forwarding, see the [subnet router guide](https://tailscale.com/kb/1019/subnets).
+
+4. In the [Tailscale admin console](https://login.tailscale.com/admin/machines), approve the advertised route on that machine.
+
+That's it. With Tailscale connected on your phone, open WLED's normal LAN IP in the browser or add it in the WLED app, exactly as if you were home.
+
+If you'd rather not rely on a third party, a plain [WireGuard](https://www.wireguard.com/) tunnel to your router or a self-hosted [Headscale](https://headscale.net/) control server gets you the same result with more setup.
+
+## Cloudflare Tunnel
+
+[Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) is a good option if you want to reach WLED from a device where you can't run a VPN client, or share access with someone else. A small daemon (`cloudflared`) on a machine in your LAN makes an outbound connection to Cloudflare, so no ports are opened on your router. You need a domain on Cloudflare (the free plan works).
+
+!!! warning "The tunnel alone is not enough"
+    A tunnel without access control is just port forwarding with extra steps. You **must** put [Cloudflare Access](https://developers.cloudflare.com/cloudflare-one/policies/access/) in front of the tunnel so only you can log in.
+
+1. In the Cloudflare dashboard, go to Zero Trust and create a tunnel. Install `cloudflared` on an always-on machine in your LAN using the command the dashboard gives you.
+2. Add a public hostname for the tunnel, for example `wled.mydomain.example`, pointing to `http://<WLED-IP>`.
+3. In Zero Trust, create an Access application for that hostname with a policy that only allows your own login, for example email one-time PIN.
+
+Now `https://wled.mydomain.example` asks for your login first and only then shows WLED.
+
+## Advanced: reverse proxy
+
+If you already run a public-facing reverse proxy, you can publish WLED through it. Two requirements are non-negotiable:
+
+- The proxy **must implement access control**, so only trusted users reach WLED.
+- The proxy **must terminate TLS** and only accept HTTPS. Access control over plain HTTP leaks your credentials.
+
+The proxy can't run on the WLED device itself. You need a server in your LAN:
 
 ```
 [Public Internet]
@@ -41,36 +68,80 @@ Assuming the following network setup, using Caddy as a reverse proxy:
 [WLED]
 ```
 
-First, register a domain name. In this example, we assume the name "mydomain.example".
-A domain name is commonly a requirement for a HTTP certificate.
-You can use a dynamic dns provider for a free domain.
+The general recipe is the same for every proxy: register a domain name (a dynamic DNS name works), get a Let's Encrypt certificate with automatic renewal, port forward TCP 443 from your router to the proxy, and configure an authenticated virtual host that proxies to WLED's LAN IP. WLED's live view uses a WebSocket, so the proxy must pass WebSocket upgrades through.
 
-Next, generate a HTTPs certificate for your domain.
-For the free Let's Encrypt certificates, configure necessary the automation for refreshing the certificate automatically.
-In this example, we are using Caddy which handles this automatically.
+=== "Caddy"
 
-We then expose the HTTPS port of the reverse proxy to public internet.
-In your network router, port forward port TCP 443 into the Reverse Proxy.
-In this example, we are using Caddy which only requires port 443 to complete the Let's Encrypt challenge for automatic certificate issuing.
-With other software, you may need to also open insecure HTTP port 80.
+    Caddy obtains and renews the Let's Encrypt certificate automatically, serves HTTPS only by default, and proxies WebSockets without extra configuration.
 
-Finally, in Caddyfile, configure the reverse proxy and authentication
-Caddy uses HTTPS by default.
-With other software, we may need to disable access over the unsafe HTTP.
+    Generate a password hash with `caddy hash-password`, then in your `Caddyfile`:
 
-```
-mydomain.example {
-  handle /wled/* {
-    # Create username and password. Password can be with `caddy hash-password --plaintext mypass`
-    basicauth {
-        yourusername PASSWORDHASH
+    ```
+    wled.mydomain.example {
+        basic_auth {
+            yourusername PASSWORDHASH
+        }
+        reverse_proxy 192.168.1.50
     }
-    uri strip_prefix /wled
-    reverse_proxy wled-wled-a.lan # IP address or the network local name of the WLED device
-  }
-}
-```
+    ```
 
-Now `https://mydomain.example/wled/` exposes WLED to the public internet using secure HTTPS and password authentication.
+    Replace `192.168.1.50` with the IP or local hostname of your WLED device. Caddy needs ports 80 and 443 forwarded for certificate issuing.
 
-For additional security, consider enabling [OTA lock password](/advanced/ota-lock).
+=== "nginx"
+
+    nginx doesn't manage certificates itself, use [Certbot](https://certbot.eff.org/) to obtain and renew the Let's Encrypt certificate. Create the password file with `htpasswd -c /etc/nginx/.htpasswd yourusername`.
+
+    ```nginx
+    server {
+        listen 443 ssl;
+        server_name wled.mydomain.example;
+
+        ssl_certificate     /etc/letsencrypt/live/wled.mydomain.example/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/wled.mydomain.example/privkey.pem;
+
+        auth_basic           "WLED";
+        auth_basic_user_file /etc/nginx/.htpasswd;
+
+        location / {
+            proxy_pass http://192.168.1.50;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+        }
+    }
+    ```
+
+    The `Upgrade` and `Connection` headers are required for WLED's live view WebSocket. Don't add a `listen 80` server block that serves WLED; if you want one, only use it to redirect to HTTPS.
+
+=== "Traefik"
+
+    With a `letsencrypt` [certificate resolver](https://doc.traefik.io/traefik/https/acme/) configured in your static configuration, add this dynamic configuration. Generate the password hash with `htpasswd -nb yourusername mypassword`.
+
+    ```yaml
+    http:
+      routers:
+        wled:
+          rule: "Host(`wled.mydomain.example`)"
+          entryPoints:
+            - websecure
+          middlewares:
+            - wled-auth
+          service: wled
+          tls:
+            certResolver: letsencrypt
+
+      middlewares:
+        wled-auth:
+          basicAuth:
+            users:
+              - "yourusername:PASSWORDHASH"
+
+      services:
+        wled:
+          loadBalancer:
+            servers:
+              - url: "http://192.168.1.50"
+    ```
+
+Whichever option you choose, also enable the [OTA lock password](/advanced/ota-lock) so the firmware can't be replaced even by someone who gets past the first layer.

--- a/docs/advanced/access-over-internet.md
+++ b/docs/advanced/access-over-internet.md
@@ -20,13 +20,13 @@ Already controlling WLED through [Home Assistant](https://www.home-assistant.io/
 
     1. Create a Tailscale account and install the app on your phone or laptop.
     2. Install Tailscale on the always-on device at home and sign it in with `sudo tailscale up`.
-    3. On that device, advertise the route to your WLED devices. A single address is enough for one controller, and safer than opening the whole LAN:
+    3. On that device, advertise your LAN subnet (adjust to match your network):
 
         ```sh
-        sudo tailscale set --advertise-routes=192.168.1.50/32
+        sudo tailscale set --advertise-routes=192.168.1.0/24
         ```
 
-        Use your own WLED IP, or a subnet like `192.168.1.0/24` if you have several devices to reach. On Linux you also need to enable IP forwarding, see the [subnet router guide](https://tailscale.com/kb/1019/subnets).
+        On Linux you also need to enable IP forwarding, see the [subnet router guide](https://tailscale.com/kb/1019/subnets).
 
     4. In the [Tailscale admin console](https://login.tailscale.com/admin/machines), approve the advertised route on that machine.
 

--- a/docs/advanced/access-over-internet.md
+++ b/docs/advanced/access-over-internet.md
@@ -20,13 +20,11 @@ Already controlling WLED through [Home Assistant](https://www.home-assistant.io/
 
     1. Create a Tailscale account and install the app on your phone or laptop.
     2. Install Tailscale on the always-on device at home and sign it in with `sudo tailscale up`.
-    3. On that device, advertise your LAN subnet (adjust to match your network):
+    3. On that device, enable IP forwarding if it runs Linux (see the [subnet router guide](https://tailscale.com/kb/1019/subnets)), then advertise your LAN subnet (adjust to match your network):
 
         ```sh
         sudo tailscale set --advertise-routes=192.168.1.0/24
         ```
-
-        On Linux you also need to enable IP forwarding, see the [subnet router guide](https://tailscale.com/kb/1019/subnets).
 
     4. In the [Tailscale admin console](https://login.tailscale.com/admin/machines), approve the advertised route on that machine.
 
@@ -42,7 +40,7 @@ Already controlling WLED through [Home Assistant](https://www.home-assistant.io/
         A tunnel without access control is just port forwarding with extra steps. You **must** put [Cloudflare Access](https://developers.cloudflare.com/cloudflare-one/policies/access/) in front of the tunnel so only you can log in.
 
     1. In the Cloudflare dashboard, go to **Networking > Tunnels** and create a tunnel. Install `cloudflared` on an always-on machine in your LAN using the command the dashboard gives you.
-    2. Under **Zero Trust**, create an Access application for the hostname you plan to use, for example `wled.mydomain.example`, with a policy that only allows your own login, such as email one-time PIN. Do this before the next step, or WLED is briefly reachable by anyone.
+    2. Under **Zero Trust**, create an Access application for the hostname you plan to use, for example `wled.mydomain.example`. Set the policy to allow your own email address, with one-time PIN as the login method. A policy that names only the login method lets in anyone with any email. Do this before the next step, or WLED is briefly reachable by anyone.
     3. Back in the tunnel, add that hostname as a public hostname pointing to `http://<WLED-IP>`.
 
     Now `https://wled.mydomain.example` asks for your login first and only then shows WLED.

--- a/docs/advanced/access-over-internet.md
+++ b/docs/advanced/access-over-internet.md
@@ -5,7 +5,7 @@ hide:
   # - toc
 ---
 
-Control your LEDs from anywhere. Pick a route below: Tailscale is the easiest and gets most people there in about ten minutes, Cloudflare Tunnel gives you a login-protected public URL, HomeKit puts WLED in the Apple Home app, and Caddy, nginx, or Traefik work if you already run a reverse proxy at home.
+Control your LEDs from anywhere. Pick a route below: Tailscale is the easiest, Cloudflare Tunnel gives you a login-protected public URL, HomeKit puts WLED in the Apple Home app, and Caddy, nginx, or Traefik work if you already run a reverse proxy at home.
 
 Already controlling WLED through [Home Assistant](https://www.home-assistant.io/integrations/wled/)? If you can reach Home Assistant remotely, you have secure remote control and don't need anything on this page.
 
@@ -60,11 +60,11 @@ Already controlling WLED through [Home Assistant](https://www.home-assistant.io/
 
 === "Caddy"
 
-    For an existing [Caddy](https://caddyserver.com/) server in your LAN with a domain pointed at your home IP (dynamic DNS works). The proxy must require a login and serve HTTPS only; Caddy does the HTTPS part by default and obtains and renews the Let's Encrypt certificate automatically.
+    This assumes an existing [Caddy](https://caddyserver.com/) server in your LAN and a domain pointed at your home IP (a free dynamic DNS name works). The proxy must require a login and serve HTTPS only; Caddy does the HTTPS part by default and obtains and renews the Let's Encrypt certificate automatically.
 
     Generate a password hash with `caddy hash-password`, put it in place of `PASSWORDHASH` in your `Caddyfile` (on Caddy older than 2.8, the directive is spelled `basicauth`):
 
-    ```
+    ```caddyfile
     wled.mydomain.example {
         basic_auth {
             yourusername PASSWORDHASH
@@ -77,7 +77,7 @@ Already controlling WLED through [Home Assistant](https://www.home-assistant.io/
 
 === "nginx"
 
-    For an existing [nginx](https://nginx.org/) server in your LAN with a domain pointed at your home IP (dynamic DNS works) and TCP 443 forwarded to it. The proxy must require a login and serve HTTPS only. nginx doesn't manage certificates itself, use [Certbot](https://certbot.eff.org/) to obtain and renew the Let's Encrypt certificate before adding this server block, since nginx won't start while the certificate paths point at nothing. Certbot's default challenge also needs TCP 80 forwarded.
+    This assumes an existing [nginx](https://nginx.org/) server in your LAN, a domain pointed at your home IP (a free dynamic DNS name works), and TCP 443 forwarded to it. The proxy must require a login and serve HTTPS only. nginx doesn't manage certificates itself, so run [Certbot](https://certbot.eff.org/) before adding this server block; nginx won't start while the certificate paths point at nothing. Certbot's default challenge also needs TCP 80 forwarded.
 
     Create the password file with `htpasswd -c /etc/nginx/.htpasswd yourusername`, then:
 
@@ -106,7 +106,7 @@ Already controlling WLED through [Home Assistant](https://www.home-assistant.io/
 
 === "Traefik"
 
-    For an existing [Traefik](https://doc.traefik.io/traefik/) instance in your LAN with a domain pointed at your home IP (dynamic DNS works), TCP 443 forwarded to it, and a `letsencrypt` [certificate resolver](https://doc.traefik.io/traefik/https/acme/) configured. The proxy must require a login and serve HTTPS only.
+    This assumes an existing [Traefik](https://doc.traefik.io/traefik/) instance in your LAN, a domain pointed at your home IP (a free dynamic DNS name works), TCP 443 forwarded to it, and a `letsencrypt` [certificate resolver](https://doc.traefik.io/traefik/https/acme/) configured. The proxy must require a login and serve HTTPS only.
 
     Generate the password hash with `htpasswd -nb yourusername mypassword`, then add this dynamic configuration in a file your [file provider](https://doc.traefik.io/traefik/providers/file/) watches:
 


### PR DESCRIPTION
Reworks the page around what most users should do, instead of leading with the hardest option.

- All routes are now content tabs, easiest first: Tailscale, Cloudflare Tunnel, HomeKit (via the Home Assistant HomeKit Bridge or Homebridge), Caddy, nginx, Traefik.
- The old page mentioned VPNs in one tip line and then only documented a reverse proxy. Tailscale is now a full walkthrough (subnet router on an always-on device), since it's the least setup and exposes nothing to the public internet.
- Caddy example updated: `basic_auth` (renamed in Caddy 2.8), a subdomain vhost instead of the `/wled/` path-strip pattern, and both 80 and 443 forwarded. The old "only requires port 443" claim doesn't match [Caddy's docs](https://caddyserver.com/docs/automatic-https), which want both ports for the ACME challenges and the HTTP redirect.
- nginx and Traefik examples added, including the WebSocket upgrade headers nginx needs for the live view (`/ws`).
- Kept: the port-forwarding warning and the OTA lock recommendation (now a tip admonition).

Commands and claims were checked against the current Tailscale, Cloudflare, Caddy, nginx, Traefik, and Apple documentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked the remote-access guide with secure options including Tailscale, Cloudflare Tunnel with Access, HomeKit, Caddy, nginx, and Traefik.
  * Added setup guidance for authentication, HTTPS, WebSocket proxying, route-specific configuration, and OTA Lock.
  * Clarified secure Tailscale routing, including full LAN subnet advertisement.
  * Added Cloudflare Access setup details and emphasized changing the default OTA Lock passphrase.
  * Clarified that Home Assistant supports remote access when securely reachable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->