### PR TITLE
Add a pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+<!-- Thanks for improving the WLED docs! -->
+
+## What Does This PR Change?
+
+<!-- A short description of what you changed and why. No essay needed. -->
+
+## Checklist
+
+- [ ] This PR covers one topic
+- [ ] Content is in English and accurate for current WLED (checked against the [WLED source](https://github.com/wled/WLED) where possible)
+- [ ] The information isn't already on another page (cross-link instead of duplicating)
+- [ ] Tone is informal and friendly, sentences are short, headings use Title Case
+- [ ] Internal links are root-relative without `.md` (e.g. `/features/segments`)
+- [ ] Images live in `docs/assets/images/content/`, not on external hosts
+- [ ] Code blocks have a language hint; callouts use `!!! info` / `tip` / `warning` / `danger`
+- [ ] A new page starts with a front matter `title` and is registered under `nav:` in `mkdocs.yml`
+- [ ] Previewed locally with `mkdocs serve` or Docker

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,8 @@ Indentation in `mkdocs.yml` is significant.
 
 ## PR Review Checklist
 
+Contributors see a condensed version of this list in the PR template (`.github/PULL_REQUEST_TEMPLATE.md`). When updating either list, keep the two in agreement.
+
 When reviewing a pull request, verify the following:
 
 ### Content

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,8 @@ For larger edits, work from a branch in your own fork rather than your `main` br
 
 Please keep each PR focused on one topic, and add a short description of what you changed and why. No need to write an essay.
 
+When you open the PR, GitHub pre-fills the description with our template, a what/why prompt and a short checklist. Fill it in rather than deleting it.
+
 ## Writing Style
 
 We're harmonizing the docs for readability, so please follow the conventions in [AGENTS.md](AGENTS.md) (our contributor and AI-agent instructions). The short version:


### PR DESCRIPTION
Adds a PR template: a prompt for a short what/why description plus a self-contained checklist of the things reviews most often catch. CONTRIBUTING.md and AGENTS.md now mention the template.

The WLED source link is absolute because GitHub injects the template into the PR body, where relative paths don't resolve.
